### PR TITLE
Fix to player not resizing on closing settings menu

### DIFF
--- a/src/Userscript/YouTubePlus.user.js
+++ b/src/Userscript/YouTubePlus.user.js
@@ -490,6 +490,7 @@
                     if (document.documentElement.classList.contains("floater")) {
                         document.documentElement.classList.remove("floater");
                         document.getElementById("movie_player").removeAttribute("style");
+                        window.dispatchEvent(new Event("resize"));
                     }
                 }
             }

--- a/src/Webextension/JS/YouTubePlus.user.js
+++ b/src/Webextension/JS/YouTubePlus.user.js
@@ -490,6 +490,7 @@
                     if (document.documentElement.classList.contains("floater")) {
                         document.documentElement.classList.remove("floater");
                         document.getElementById("movie_player").removeAttribute("style");
+                        window.dispatchEvent(new Event("resize"));
                     }
                 }
             }


### PR DESCRIPTION
When closing the YT+ Settings and the floater mode was enable, the player wasn't going back to the normal