### PR TITLE
Added "Unstick header" feature

### DIFF
--- a/Locale/tr_TR.json
+++ b/Locale/tr_TR.json
@@ -44,6 +44,7 @@
     "GEN_REM_APUN"          : "Bir sonrakini otomatik oynatmayı durdur",
     "GEN_SPF_OFF"           : "SPF'i devre dışı bırak",
     "GEN_HIDE_FTR"          : "Altbilgiyi gizle",
+    "GEN_UNST_HDR"          : "Başlığı sabitle",
     "GEN_BLUE_GLOW"         : "Tıklanmış butonların etrafındaki mavi çerçeveyi kaldır",
     "GEN_HDE_RECM_SDBR"     : "Önerilen kanallar sidebar'ını gizle",
     "GEN_HDE_SRCH_SDBR"     : "Arama sonuçları sidebar'ını gizle",

--- a/src/Userscript/YouTubePlus.user.js
+++ b/src/Userscript/YouTubePlus.user.js
@@ -246,6 +246,7 @@
                             <div><input id='GEN_HDE_RECM_SDBR' type='checkbox'></input><label for='GEN_HDE_RECM_SDBR' data-p='tnd|GEN_HDE_RECM_SDBR'><svg><use xlink:href='#ytp-svg-checkmark'/></svg></label>\n<a href='https://github.com/ParticleCore/Particle/wiki/Features#hide_recom_sidebar' data-p='ttl|FTR_DESC' target='features'>?</a></div>
                             <div><input id='GEN_HDE_SRCH_SDBR' type='checkbox'></input><label for='GEN_HDE_SRCH_SDBR' data-p='tnd|GEN_HDE_SRCH_SDBR'><svg><use xlink:href='#ytp-svg-checkmark'/></svg></label>\n<a href='https://github.com/ParticleCore/Particle/wiki/Features#hide_search_sidebar' data-p='ttl|FTR_DESC' target='features'>?</a></div>
                             <div><input id='GEN_HDE_CHN_SDBR'  type='checkbox'></input><label for='GEN_HDE_CHN_SDBR'  data-p='tnd|GEN_HDE_CHN_SDBR'> <svg><use xlink:href='#ytp-svg-checkmark'/></svg></label>\n<a href='https://github.com/ParticleCore/Particle/wiki/Features#hide_channel_sidebar' data-p='ttl|FTR_DESC' target='features'>?</a></div>
+                            <div><input id='GEN_UNST_HDR'      type='checkbox'></input><label for='GEN_UNST_HDR'      data-p='tnd|GEN_UNST_HDR'>     <svg><use xlink:href='#ytp-svg-checkmark'/></svg></label>\n<a href='https://github.com/ParticleCore/Particle/wiki/Features#unstick_header' data-p='ttl|FTR_DESC' target='features'>?</a></div>
                         </div>`;
                     if (user_settings.GEN_LOCL_LANG && user_settings.localLang) {
                         temp.content.querySelector(".P-implang").dataset.p = "GLB_LOCL_LANG_CSTM";
@@ -1710,6 +1711,9 @@
                     if (user_settings.VID_PLR_FIT) {
                         modPlayerSize();
                     }
+                    if (user_settings.GEN_UNST_HDR){
+                        document.getElementById("masthead-positioner").style.position = "absolute";
+                    }
                     Object.keys(customStyles.custom_styles).forEach(setCustomStyles);
                     if (window.location.href.split("/feed/subscriptions").length < 2) {
                         document.documentElement.classList.remove("part_grid_subs");
@@ -2012,6 +2016,7 @@
                 GEN_INF_SCRL    : true,
                 GEN_BLUE_GLOW   : true,
                 GEN_PPOT_ON     : true,
+                GEN_UNST_HDR    : false,
                 VID_END_SHRE    : true,
                 VID_DFLT_QLTY   : "auto",
                 VID_PLST_ATPL   : true,
@@ -2083,6 +2088,7 @@
                 GEN_REM_APUN          : "Remove autoplay up next",
                 GEN_SPF_OFF           : "Disable SPF",
                 GEN_HIDE_FTR          : "Hide footer",
+                GEN_UNST_HDR          : "Unstick header",
                 GEN_BLUE_GLOW         : "Remove blue glow around clicked buttons",
                 GEN_HDE_RECM_SDBR     : "Hide recommended channels sidebar",
                 GEN_HDE_SRCH_SDBR     : "Hide search results sidebar",


### PR DESCRIPTION
"Unstick header" feature lets users change position of header from fixed to absolute. Fixed header blocks upper part of video if you are watching in cinematic mode.
@GKid94 [https://github.com/ParticleCore/Particle/issues/278](https://github.com/ParticleCore/Particle/issues/278) and @snintendog [https://github.com/ParticleCore/Particle/issues/36](https://github.com/ParticleCore/Particle/issues/36) had same problem before.